### PR TITLE
Invalidates token if it expires right now

### DIFF
--- a/alf/tokens.py
+++ b/alf/tokens.py
@@ -18,4 +18,4 @@ class Token(object):
         self._expires_on = datetime.now() + timedelta(seconds=self._expires_in)
 
     def is_valid(self):
-        return self._expires_on >= datetime.now()
+        return self._expires_on > datetime.now()


### PR DESCRIPTION
When creating a Token expires_in default is zero. In that case the token should already have expired, as tested by: test_should_know_when_it_has_expired. However, if Token.is_valid is called before any microseconds have passed (very unlikely), Token.is_valid would return true, when it should return false.
