### PR TITLE
Add an optional token request timeout parameter

### DIFF
--- a/alf/client.py
+++ b/alf/client.py
@@ -19,7 +19,7 @@ class Client(requests.Session):
         self._client_id = kwargs.pop('client_id')
         self._client_secret = kwargs.pop('client_secret')
         self._token_storage = kwargs.pop('token_storage', None)
-        self._token_request_timeout = kwargs.pop('token_request_timeout', None)
+        self._token_request_params = kwargs.pop('token_request_params', None)
 
         _token_retries = kwargs.pop('token_retries', None)
         self._token_manager = self.token_manager_class(
@@ -27,7 +27,7 @@ class Client(requests.Session):
             client_id=self._client_id,
             client_secret=self._client_secret,
             token_storage=self._token_storage,
-            token_request_timeout=self._token_request_timeout,
+            token_request_params=self._token_request_params,
             token_retries=_token_retries)
 
         super(Client, self).__init__(*args, **kwargs)

--- a/alf/client.py
+++ b/alf/client.py
@@ -19,6 +19,7 @@ class Client(requests.Session):
         self._client_id = kwargs.pop('client_id')
         self._client_secret = kwargs.pop('client_secret')
         self._token_storage = kwargs.pop('token_storage', None)
+        self._token_request_timeout = kwargs.pop('token_request_timeout', None)
 
         _token_retries = kwargs.pop('token_retries', None)
         self._token_manager = self.token_manager_class(
@@ -26,6 +27,7 @@ class Client(requests.Session):
             client_id=self._client_id,
             client_secret=self._client_secret,
             token_storage=self._token_storage,
+            token_request_timeout=self._token_request_timeout,
             token_retries=_token_retries)
 
         super(Client, self).__init__(*args, **kwargs)

--- a/alf/managers.py
+++ b/alf/managers.py
@@ -10,11 +10,11 @@ class TokenManager(object):
 
     def __init__(self, token_endpoint, client_id, client_secret,
                  token_storage=None, token_retries=None,
-                 token_request_timeout=None):
+                 token_request_params=None):
         self._token_endpoint = token_endpoint
         self._client_id = client_id
         self._client_secret = client_secret
-        self._token_request_timeout = token_request_timeout
+        self._token_request_params = token_request_params or {}
         self._token_storage = TokenStorage(token_storage)
 
         self._session = requests.Session()
@@ -59,7 +59,7 @@ class TokenManager(object):
             self._token_endpoint,
             data={'grant_type': 'client_credentials'},
             auth=(self._client_id, self._client_secret),
-            timeout=self._token_request_timeout)
+            timeout=self._token_request_params.get('timeout'))
 
         if not response.ok:
             raise TokenError('Failed to request token', response)

--- a/alf/managers.py
+++ b/alf/managers.py
@@ -9,10 +9,12 @@ from alf.adapters import mount_retry_adapter
 class TokenManager(object):
 
     def __init__(self, token_endpoint, client_id, client_secret,
-                 token_storage=None, token_retries=None):
+                 token_storage=None, token_retries=None,
+                 token_request_timeout=None):
         self._token_endpoint = token_endpoint
         self._client_id = client_id
         self._client_secret = client_secret
+        self._token_request_timeout = token_request_timeout
         self._token_storage = TokenStorage(token_storage)
 
         self._session = requests.Session()
@@ -56,7 +58,8 @@ class TokenManager(object):
         response = self._session.post(
             self._token_endpoint,
             data={'grant_type': 'client_credentials'},
-            auth=(self._client_id, self._client_secret))
+            auth=(self._client_id, self._client_secret),
+            timeout=self._token_request_timeout)
 
         if not response.ok:
             raise TokenError('Failed to request token', response)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -28,13 +28,17 @@ class TestClient(TestCase):
             token_endpoint=self.end_point,
             client_id='client_id',
             client_secret='client_secret',
-            token_request_timeout=10
+            token_request_params={
+                'timeout': 10
+            }
         )
 
         init.assert_called_with(client_id='client_id',
                                 client_secret='client_secret',
                                 token_endpoint=self.end_point,
-                                token_request_timeout=10,
+                                token_request_params={
+                                    'timeout': 10
+                                },
                                 token_retries=None,
                                 token_storage=None)
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -20,6 +20,24 @@ class TestClient(TestCase):
 
         self.assertTrue(isinstance(client._token_manager, client.token_manager_class))
 
+    @patch('alf.client.TokenManager.__init__')
+    def test_should_have_token_request_timeout(self, init):
+        init.return_value = None
+
+        client = Client(
+            token_endpoint=self.end_point,
+            client_id='client_id',
+            client_secret='client_secret',
+            token_request_timeout=10
+        )
+
+        init.assert_called_with(client_id='client_id',
+                                client_secret='client_secret',
+                                token_endpoint=self.end_point,
+                                token_request_timeout=10,
+                                token_retries=None,
+                                token_storage=None)
+
     @patch('alf.client.TokenManager')
     @patch('requests.Session.request')
     def test_should_retry_a_bad_request_once(self, request, Manager):

--- a/tests/managers/test_token_manager.py
+++ b/tests/managers/test_token_manager.py
@@ -53,6 +53,22 @@ class TokenManagerTestCase(BaseTokenManagerTestCase):
         self.manager._request_token()
 
         post.assert_called_with(self.END_POINT,
+                                timeout=None,
+                                data={'grant_type': 'client_credentials'},
+                                auth=(self.CLIENT_ID, self.CLIENT_SECRET))
+
+    @patch('requests.Session.post')
+    def test_should_have_token_request_timeout(self, post):
+        post.return_value.json.return_value = {}
+        manager = TokenManager(
+            self.END_POINT, self.CLIENT_ID, self.CLIENT_SECRET,
+            token_request_timeout=5
+        )
+
+        manager._request_token()
+
+        post.assert_called_with(self.END_POINT,
+                                timeout=5,
                                 data={'grant_type': 'client_credentials'},
                                 auth=(self.CLIENT_ID, self.CLIENT_SECRET))
 

--- a/tests/managers/test_token_manager.py
+++ b/tests/managers/test_token_manager.py
@@ -62,7 +62,9 @@ class TokenManagerTestCase(BaseTokenManagerTestCase):
         post.return_value.json.return_value = {}
         manager = TokenManager(
             self.END_POINT, self.CLIENT_ID, self.CLIENT_SECRET,
-            token_request_timeout=5
+            token_request_params={
+                'timeout': 5
+            }
         )
 
         manager._request_token()


### PR DESCRIPTION
The parameter `token_request_timeout` defines how many seconds to wait for the
server to send data before giving up, as a float, or a (connect timeout, read
timeout) tuple. Defaults to None.

By passing float, the timeout value will be applied to both the connect and the
read timeouts. Specify a tuple if you would like to set the values separately.

More detail:
http://docs.python-requests.org/en/master/user/advanced/#timeouts