### PR TITLE
Fix storage and retrieval of date time format

### DIFF
--- a/alf/tokens.py
+++ b/alf/tokens.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 TOKEN_KEY = 'access_token'
 TOKEN_VALUE = ''
 TOKEN_EXPIRES = 'expires_on'
+TOKEN_EXPIRES_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 
 
 class TokenError(Exception):
@@ -39,14 +40,15 @@ class TokenStorage(object):
             self._access_token = token.access_token
             self._expires_on = token.expires_on
             self._storage.set(TOKEN_KEY, token.access_token)
-            self._storage.set(TOKEN_EXPIRES, str(token.expires_on))
+            self._storage.set(TOKEN_EXPIRES,
+                              token.expires_on.strftime(TOKEN_EXPIRES_FORMAT))
 
     def request_token(self):
         self._access_token = self._storage.get(TOKEN_KEY)
         expires_on = self._storage.get(TOKEN_EXPIRES)
         if expires_on:
             self._expires_on = datetime.strptime(expires_on,
-                                                 "%Y-%m-%d %H:%M:%S.%f")
+                                                 TOKEN_EXPIRES_FORMAT)
         else:
             self._expires_on = datetime.now()
         if self._access_token and self._expires_on > datetime.now():
@@ -65,4 +67,3 @@ class TokenDefaultStorage(object):
 
     def set(self, key=TOKEN_KEY, value=TOKEN_VALUE):
         self.storage[key] = value
-

--- a/tests/tokens/test_token.py
+++ b/tests/tokens/test_token.py
@@ -49,6 +49,17 @@ class TestTokenStorage(unittest.TestCase):
         expires = str(token.expires_on)
         self.assertEqual(self.storage_obj.get(TOKEN_EXPIRES), expires, self.storage_obj)
 
+    @freeze_time('2015-01-01 10:12:10.000000')
+    def test_storage_should_respect_datetime_format(self):
+        token = Token(access_token='access_token',
+                      expires_on=Token.calc_expires_on(10))
+        token_storage = TokenStorage(self.storage_obj)
+        token_storage(token)
+
+        expires = token_storage.request_token()[TOKEN_EXPIRES]
+        expected = datetime(2015, 1, 1, 10, 12, 20, microsecond=0)
+        self.assertEqual(expires, expected)
+
     def test_storage_should_add_retrieve_token(self):
         token = Token(access_token='access_token',
                       expires_on=Token.calc_expires_on(10))
@@ -99,4 +110,3 @@ class TestTokenMemcached(TestTokenStorage):
 
     def tearDown(self):
         self.storage_obj.delete('access_token')
-


### PR DESCRIPTION
When a date time is converted to a string, the microseconds may be truncated if
equals zero. To avoid that, the date time must use functions like `strftime` and
`strptime` to store and retrieve the same date time format.